### PR TITLE
Allow Start to be called immediately after Stop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,28 @@
 language: go
 sudo: false
+
+matrix:
+  include:
+    - go: 1.11.x
+      os: linux
+    - go: 1.12.x
+      os: linux
+    - go: 1.11.x
+      os: linux
+      env: CROSS_COMPILE=true
+    - go: 1.12.x
+      os: linux
+      env: CROSS_COMPILE=true
+    - go: 1.11.x
+      os: osx
+    - go: 1.12.x
+      os: osx
+
 install:
-  - go get ./...
-go:
-  - 1.4
-  - tip
+  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CROSS_COMPILE" = "true" ]; then go get github.com/mattn/go-isatty ; fi
+  - go get -t -v ./...
+
+script:
+  - go build
+  - go test
+  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CROSS_COMPILE" = "true" ]; then env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -v; fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test:
+	@go test -race .
+
+examples:
+	@go run -race ./example
+
+.PHONY: test examples

--- a/example/main.go
+++ b/example/main.go
@@ -13,14 +13,15 @@ func main() {
 	// start listening for updates and render
 	writer.Start()
 
-	for _, f := range []string{"Foo.zip", "Bar.iso"} {
+	for _, f := range [][]string{{"Foo.zip", "Bar.iso"}, {"Baz.tar.gz", "Qux.img"}} {
 		for i := 0; i <= 50; i++ {
-			fmt.Fprintf(writer, "Downloading %s.. (%d/%d) GB\n", f, i, 50)
+			_, _ = fmt.Fprintf(writer, "Downloading %s.. (%d/%d) GB\n", f[0], i, 50)
+			_, _ = fmt.Fprintf(writer.Newline(), "Downloading %s.. (%d/%d) GB\n", f[1], i, 50)
 			time.Sleep(time.Millisecond * 25)
 		}
-		fmt.Fprintf(writer.Bypass(), "Downloaded %s\n", f)
+		_, _ = fmt.Fprintf(writer.Bypass(), "Downloaded %s\n", f[0])
+		_, _ = fmt.Fprintf(writer.Bypass(), "Downloaded %s\n", f[1])
 	}
-
-	fmt.Fprintln(writer, "Finished: Downloaded 100GB")
+	_, _ = fmt.Fprintln(writer, "Finished: Downloaded 150GB")
 	writer.Stop() // flush and stop rendering
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gosuri/uilive
+
+go 1.10

--- a/terminal_size.go
+++ b/terminal_size.go
@@ -1,0 +1,37 @@
+package uilive
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+type windowSize struct {
+	rows    uint16
+	cols    uint16
+	xPixels uint16
+	yPixels uint16
+}
+
+var out *os.File
+var err error
+var sz windowSize
+
+func getTermSize() (int, int) {
+	if runtime.GOOS == "openbsd" {
+		out, err = os.OpenFile("/dev/tty", os.O_RDWR, 0)
+		if err != nil {
+			os.Exit(1)
+		}
+
+	} else {
+		out, err = os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+		if err != nil {
+			os.Exit(1)
+		}
+	}
+	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL,
+		out.Fd(), uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&sz)))
+	return int(sz.cols), int(sz.rows)
+}

--- a/terminal_size.go
+++ b/terminal_size.go
@@ -12,8 +12,6 @@ import (
 type windowSize struct {
 	rows    uint16
 	cols    uint16
-	xPixels uint16
-	yPixels uint16
 }
 
 var out *os.File

--- a/terminal_size.go
+++ b/terminal_size.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package uilive
 
 import (
@@ -22,13 +24,13 @@ func getTermSize() (int, int) {
 	if runtime.GOOS == "openbsd" {
 		out, err = os.OpenFile("/dev/tty", os.O_RDWR, 0)
 		if err != nil {
-			os.Exit(1)
+			return 0, 0
 		}
 
 	} else {
 		out, err = os.OpenFile("/dev/tty", os.O_WRONLY, 0)
 		if err != nil {
-			os.Exit(1)
+			return 0, 0
 		}
 	}
 	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL,

--- a/terminal_size_windows.go
+++ b/terminal_size_windows.go
@@ -1,0 +1,63 @@
+// +build windows
+
+package uilive
+
+import (
+	"math"
+	"syscall"
+	"unsafe"
+)
+
+type consoleFontInfo struct {
+	font     uint32
+	fontSize coord
+}
+
+const (
+	SmCxMin = 28
+	SmCyMin = 29
+)
+
+var (
+	tmpConsoleFontInfo        consoleFontInfo
+	moduleUser32              = syscall.NewLazyDLL("user32.dll")
+	procGetCurrentConsoleFont = kernel32.NewProc("GetCurrentConsoleFont")
+	getSystemMetrics          = moduleUser32.NewProc("GetSystemMetrics")
+)
+
+func getCurrentConsoleFont(h syscall.Handle, info *consoleFontInfo) (err error) {
+	r0, _, e1 := syscall.Syscall(
+		procGetCurrentConsoleFont.Addr(), 3, uintptr(h), 0, uintptr(unsafe.Pointer(info)),
+	)
+	if int(r0) == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func getTermSize() (int, int) {
+	out, err := syscall.Open("CONOUT$", syscall.O_RDWR, 0)
+	if err != nil {
+		return 0, 0
+	}
+
+	x, _, err := getSystemMetrics.Call(SmCxMin)
+	y, _, err := getSystemMetrics.Call(SmCyMin)
+
+	if x == 0 || y == 0 {
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	err = getCurrentConsoleFont(out, &tmpConsoleFontInfo)
+	if err != nil {
+		panic(err)
+	}
+
+	return int(math.Ceil(float64(x) / float64(tmpConsoleFontInfo.fontSize.x))), int(math.Ceil(float64(y) / float64(tmpConsoleFontInfo.fontSize.y)))
+}

--- a/terminal_size_windows.go
+++ b/terminal_size_windows.go
@@ -3,61 +3,21 @@
 package uilive
 
 import (
-	"math"
-	"syscall"
+	"os"
 	"unsafe"
 )
 
-type consoleFontInfo struct {
-	font     uint32
-	fontSize coord
-}
-
-const (
-	SmCxMin = 28
-	SmCyMin = 29
-)
-
-var (
-	tmpConsoleFontInfo        consoleFontInfo
-	moduleUser32              = syscall.NewLazyDLL("user32.dll")
-	procGetCurrentConsoleFont = kernel32.NewProc("GetCurrentConsoleFont")
-	getSystemMetrics          = moduleUser32.NewProc("GetSystemMetrics")
-)
-
-func getCurrentConsoleFont(h syscall.Handle, info *consoleFontInfo) (err error) {
-	r0, _, e1 := syscall.Syscall(
-		procGetCurrentConsoleFont.Addr(), 3, uintptr(h), 0, uintptr(unsafe.Pointer(info)),
-	)
-	if int(r0) == 0 {
-		if e1 != 0 {
-			err = error(e1)
-		} else {
-			err = syscall.EINVAL
-		}
-	}
-	return
-}
-
 func getTermSize() (int, int) {
-	out, err := syscall.Open("CONOUT$", syscall.O_RDWR, 0)
+	out, err := os.Open("CONOUT$")
 	if err != nil {
 		return 0, 0
 	}
 
-	x, _, err := getSystemMetrics.Call(SmCxMin)
-	y, _, err := getSystemMetrics.Call(SmCyMin)
-
-	if x == 0 || y == 0 {
-		if err != nil {
-			panic(err)
-		}
+	var csbi consoleScreenBufferInfo
+	ret, _, _ := procGetConsoleScreenBufferInfo.Call(out.Fd(), uintptr(unsafe.Pointer(&csbi)))
+	if ret == 0 {
+		return 0, 0
 	}
 
-	err = getCurrentConsoleFont(out, &tmpConsoleFontInfo)
-	if err != nil {
-		panic(err)
-	}
-
-	return int(math.Ceil(float64(x) / float64(tmpConsoleFontInfo.fontSize.x))), int(math.Ceil(float64(y) / float64(tmpConsoleFontInfo.fontSize.y)))
+	return int(csbi.window.right - csbi.window.left + 1), int(csbi.window.bottom - csbi.window.top + 1)
 }

--- a/terminal_size_windows.go
+++ b/terminal_size_windows.go
@@ -12,6 +12,7 @@ func getTermSize() (int, int) {
 	if err != nil {
 		return 0, 0
 	}
+	defer out.Close()
 
 	var csbi consoleScreenBufferInfo
 	ret, _, _ := procGetConsoleScreenBufferInfo.Call(out.Fd(), uintptr(unsafe.Pointer(&csbi)))

--- a/writer.go
+++ b/writer.go
@@ -16,7 +16,7 @@ const ESC = 27
 var RefreshInterval = time.Millisecond
 
 // Out is the default output writer for the Writer
-var Out = os.Stdout
+var Out = io.Writer(os.Stdout)
 
 // ErrClosedPipe is the error returned when trying to writer is not listening
 var ErrClosedPipe = errors.New("uilive: read/write on closed pipe")

--- a/writer.go
+++ b/writer.go
@@ -115,7 +115,7 @@ func (w *Writer) Start() {
 
 // Stop stops the listener that updates the terminal
 func (w *Writer) Stop() {
-	w.Flush()
+	_ = w.Flush()
 	close(w.tdone)
 }
 
@@ -125,7 +125,7 @@ func (w *Writer) Listen() {
 		select {
 		case <-w.ticker.C:
 			if w.ticker != nil {
-				w.Flush()
+				_ = w.Flush()
 			}
 		case <-w.tdone:
 			w.mtx.Lock()

--- a/writer_posix.go
+++ b/writer_posix.go
@@ -4,11 +4,12 @@ package uilive
 
 import (
 	"fmt"
+	"strings"
 )
 
+// clear the line and move the cursor up
+var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
+
 func (w *Writer) clearLines() {
-	for i := 0; i < w.lineCount; i++ {
-		fmt.Fprintf(w.Out, "%c[2K", ESC)     // clear the line
-		fmt.Fprintf(w.Out, "%c[%dA", ESC, 1) // move the cursor up
-	}
+	_, _ = fmt.Fprint(w.Out, strings.Repeat(clear, w.lineCount))
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -22,3 +22,14 @@ func TestWriter(t *testing.T) {
 		t.Fatalf("want %q, got %q", want, b.String())
 	}
 }
+
+func TestStartCalledTwice(t *testing.T) {
+	w := New()
+	b := &bytes.Buffer{}
+	w.Out = b
+
+	w.Start()
+	w.Stop()
+	w.Start()
+	w.Stop()
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -12,10 +12,10 @@ func TestWriter(t *testing.T) {
 	w.Out = b
 	w.Start()
 	for i := 0; i < 2; i++ {
-		fmt.Fprintln(w, "foo")
+		_, _ = fmt.Fprintln(w, "foo")
 	}
 	w.Stop()
-	fmt.Fprintln(b, "bar")
+	_, _ = fmt.Fprintln(b, "bar")
 
 	want := "foo\nfoo\nbar\n"
 	if b.String() != want {

--- a/writer_windows.go
+++ b/writer_windows.go
@@ -4,7 +4,6 @@ package uilive
 
 import (
 	"fmt"
-	"github.com/mattn/go-isatty"
 	"syscall"
 	"unsafe"
 )
@@ -17,6 +16,9 @@ var (
 	procFillConsoleOutputCharacter = kernel32.NewProc("FillConsoleOutputCharacterW")
 	procFillConsoleOutputAttribute = kernel32.NewProc("FillConsoleOutputAttribute")
 )
+
+// clear the line and move the cursor up
+var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
 
 type short int16
 type dword uint32
@@ -48,10 +50,7 @@ func (w *Writer) clearLines() {
 		ok = false
 	}
 	if !ok {
-		for i := 0; i < w.lineCount; i++ {
-			fmt.Fprintf(w.Out, "%c[%dA", ESC, 0) // move the cursor up
-			fmt.Fprintf(w.Out, "%c[2K\r", ESC)   // clear the line
-		}
+		_, _ = fmt.Fprint(w.Out, strings.Repeat(clear, w.lineCount))
 		return
 	}
 	fd := f.Fd()

--- a/writer_windows.go
+++ b/writer_windows.go
@@ -4,8 +4,10 @@ package uilive
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 	"unsafe"
+	"github.com/mattn/go-isatty"
 )
 
 var kernel32 = syscall.NewLazyDLL("kernel32.dll")
@@ -14,11 +16,10 @@ var (
 	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
 	procSetConsoleCursorPosition   = kernel32.NewProc("SetConsoleCursorPosition")
 	procFillConsoleOutputCharacter = kernel32.NewProc("FillConsoleOutputCharacterW")
-	procFillConsoleOutputAttribute = kernel32.NewProc("FillConsoleOutputAttribute")
 )
 
 // clear the line and move the cursor up
-var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
+var clear = fmt.Sprintf("%c[%dA%c[2K\r", ESC, 0, ESC)
 
 type short int16
 type dword uint32
@@ -55,12 +56,12 @@ func (w *Writer) clearLines() {
 	}
 	fd := f.Fd()
 	var csbi consoleScreenBufferInfo
-	procGetConsoleScreenBufferInfo.Call(fd, uintptr(unsafe.Pointer(&csbi)))
+	_, _, _ = procGetConsoleScreenBufferInfo.Call(fd, uintptr(unsafe.Pointer(&csbi)))
 
 	for i := 0; i < w.lineCount; i++ {
 		// move the cursor up
 		csbi.cursorPosition.y--
-		procSetConsoleCursorPosition.Call(fd, uintptr(*(*int32)(unsafe.Pointer(&csbi.cursorPosition))))
+		_, _, _ = procSetConsoleCursorPosition.Call(fd, uintptr(*(*int32)(unsafe.Pointer(&csbi.cursorPosition))))
 		// clear the line
 		cursor := coord{
 			x: csbi.window.left,
@@ -68,6 +69,6 @@ func (w *Writer) clearLines() {
 		}
 		var count, w dword
 		count = dword(csbi.size.x)
-		procFillConsoleOutputCharacter.Call(fd, uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&w)))
+		_, _, _ = procFillConsoleOutputCharacter.Call(fd, uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&w)))
 	}
 }


### PR DESCRIPTION
- Prior to this change the library would panic if you called Start a
  second time immediately after calling Stop
- This change updates Stop to block until the background Listen method is
  finished

Signed-off-by: Genevieve Lesperance <glesperance@pivotal.io>