### PR TITLE
Fixing "blinking" printing issue when text to be replaced is too large.

### DIFF
--- a/writer_posix.go
+++ b/writer_posix.go
@@ -4,11 +4,12 @@ package uilive
 
 import (
 	"fmt"
+	"strings"
 )
 
+// clear the line and move the cursor up
+var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
+
 func (w *Writer) clearLines() {
-	for i := 0; i < w.lineCount; i++ {
-		fmt.Fprintf(w.Out, "%c[2K", ESC)     // clear the line
-		fmt.Fprintf(w.Out, "%c[%dA", ESC, 1) // move the cursor up
-	}
+	fmt.Fprint(w.Out, strings.Repeat(clear, w.lineCount))
 }

--- a/writer_windows.go
+++ b/writer_windows.go
@@ -4,9 +4,11 @@ package uilive
 
 import (
 	"fmt"
-	"github.com/mattn/go-isatty"
+	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/mattn/go-isatty"
 )
 
 var kernel32 = syscall.NewLazyDLL("kernel32.dll")
@@ -17,6 +19,9 @@ var (
 	procFillConsoleOutputCharacter = kernel32.NewProc("FillConsoleOutputCharacterW")
 	procFillConsoleOutputAttribute = kernel32.NewProc("FillConsoleOutputAttribute")
 )
+
+// clear the line and move the cursor up
+var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
 
 type short int16
 type dword uint32
@@ -48,10 +53,7 @@ func (w *Writer) clearLines() {
 		ok = false
 	}
 	if !ok {
-		for i := 0; i < w.lineCount; i++ {
-			fmt.Fprintf(w.Out, "%c[%dA", ESC, 0) // move the cursor up
-			fmt.Fprintf(w.Out, "%c[2K\r", ESC)   // clear the line
-		}
+		fmt.Fprint(w.Out, strings.Repeat(clear, w.lineCount))
 		return
 	}
 	fd := f.Fd()


### PR DESCRIPTION
Just a performance improvement I have made to my fork.

If you are rewriting ~10 lines or more sometimes you see the screen blinking...

Related:
#11