### PR TITLE
Fixes clearLines for posix systems. See https://github.com/gosuri/uil…

### DIFF
--- a/writer_posix.go
+++ b/writer_posix.go
@@ -8,7 +8,7 @@ import (
 
 func (w *Writer) clearLines() {
 	for i := 0; i < w.lineCount; i++ {
-		fmt.Fprintf(w.Out, "%c[2K", ESC)     // clear the line
 		fmt.Fprintf(w.Out, "%c[%dA", ESC, 1) // move the cursor up
+		fmt.Fprintf(w.Out, "%c[2K", ESC)     // clear the line
 	}
 }


### PR DESCRIPTION
This fixes #11.
The problem was that the current line is cleared before the curser is moved up. The windows version already does this this in the correct order.